### PR TITLE
Add static methods to convert matrices

### DIFF
--- a/OVRSharp/Math/Matrix.cs
+++ b/OVRSharp/Math/Matrix.cs
@@ -1,0 +1,67 @@
+﻿using Valve.VR;
+using System.Numerics;
+
+namespace OVRSharp.Math
+{
+    public static class MatrixExtension
+    {
+        /// <summary>
+        /// Converts a <see cref="Matrix4x4"/> to a <see cref="HmdMatrix34_t"/>.
+        /// <br/>
+        /// <br/>
+        /// From: <br/>
+        /// 11 12 13 14 <br/>
+        /// 21 22 23 24 <br/>
+        /// 31 32 33 34 <br/>
+        /// 41 42 43 44
+        /// <br/><br/>
+        /// To: <br/>
+        /// 11 12 13 41 <br/>
+        /// 21 22 23 42 <br/>
+        /// 31 32 33 43
+        /// </summary>
+        public static HmdMatrix34_t ToHmdMatrix34_t(this Matrix4x4 matrix)
+        {
+            return new HmdMatrix34_t()
+            {
+                m0 = matrix.M11,
+                m1 = matrix.M12,
+                m2 = matrix.M13,
+                m3 = matrix.M41,
+                m4 = matrix.M21,
+                m5 = matrix.M22,
+                m6 = matrix.M23,
+                m7 = matrix.M42,
+                m8 = matrix.M31,
+                m9 = matrix.M32,
+                m10 = matrix.M33,
+                m11 = matrix.M43,
+            };
+        }
+
+        /// <summary>
+        /// Converts a <see cref="HmdMatrix34_t"/> to a <see cref="Matrix4x4"/>.
+        /// <br/>
+        /// <br/>
+        /// From: <br/>
+        /// 11 12 13 14 <br/>
+        /// 21 22 23 24 <br/>
+        /// 31 32 33 34
+        /// <br/><br/>
+        /// To: <br/>
+        /// 11 12 13 XX <br/>
+        /// 21 22 23 XX <br/>
+        /// 31 32 33 XX <br/>
+        /// 14 24 34 XX
+        /// </summary>
+        public static Matrix4x4 ToMatrix4x4(this HmdMatrix34_t matrix)
+        {
+            return new Matrix4x4(
+                matrix.m0, matrix.m1, matrix.m2, 0,
+                matrix.m4, matrix.m5, matrix.m6, 0,
+                matrix.m8, matrix.m9, matrix.m10, 0,
+                matrix.m3, matrix.m7, matrix.m11, 1
+            );
+        }
+    }
+}

--- a/OVRSharp/OVRSharp.csproj
+++ b/OVRSharp/OVRSharp.csproj
@@ -36,4 +36,8 @@
       <PackagePath>\</PackagePath>
     </Content>
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
I've added two methods to convert a `HmdMatrix34_t` to a [`Matrix4x4` ](https://docs.microsoft.com/en-us/dotnet/api/system.numerics.matrix4x4?view=net-5.0) and vice versa.

The purpose is to ease transformations, here's an example:

```csharp
double radians = (Math.PI / 180) * 45; // 45 degrees to radians
var rotation = Matrix4x4.CreateRotationX(radians);
var translation = Matrix4x4.CreateTranslation(0, -0.3f, -0.9f);
var transform = Matrix4x4.Multiply(rotation, translation);

Overlay overlay = new("key", "name")
{
    Transform = OVRSharp.Math.Matrix.ConvertNet4x4ToOpenVr3x4(transform),
};
```

There's one drawback: I had to include the `System.Numerics.Vectors` package. Not sure why (I'm new to .NET) because I didn't have to do that on my own project, maybe it depends on the target framework and/or the output type?

If the included package is a no-go, feel free to close the PR. The code is not lost and I will still use it in my own project.