### PR TITLE
Add documentation to the NuGet package

### DIFF
--- a/OVRSharp/OVRSharp.csproj
+++ b/OVRSharp/OVRSharp.csproj
@@ -11,6 +11,7 @@
     <PackageTags>openvr</PackageTags>
     <Copyright>2020-2021 TJ Horner</Copyright>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Product>OVRSharp</Product>
     <Version>1.0.1</Version>
   </PropertyGroup>


### PR DESCRIPTION
The classes/methods/properties documentation was missing in the NuGet package.