### PR TITLE
Add a default event used when no specific event matches 

### DIFF
--- a/OVRSharp/Overlay.cs
+++ b/OVRSharp/Overlay.cs
@@ -21,6 +21,7 @@ namespace OVRSharp
         public event EventHandler<VREvent_t> OnMouseMove;
         public event EventHandler<VREvent_t> OnMouseDown;
         public event EventHandler<VREvent_t> OnMouseUp;
+        public event EventHandler<VREvent_t> OnUnknown;
 
         public readonly string Key;
         public readonly string Name;
@@ -466,6 +467,9 @@ namespace OVRSharp
                         break;
                     case EVREventType.VREvent_MouseButtonUp:
                         OnMouseUp?.Invoke(this, evt);
+                        break;
+                    default:
+                        OnUnknown?.Invoke(this, evt);
                         break;
                 }
             }


### PR DESCRIPTION
This allows to use the mouse events and the `StartPolling()` method but still listen for other events than the provided ones:

```csharp
overlay.OnMouseMove += (s, e) =>
{
    //
};

overlay.OnUnknown += (s, e) =>
{
    switch ((EVREventType)e.eventType)
    {
        case EVREventType.VREvent_ScrollSmooth:
            //
            break;
        case EVREventType.VREvent_KeyboardCharInput:
            //
            break;
    }
};

overlay.StartPolling();
```